### PR TITLE
adding back dbapi module for backward compatibility with sqlalchemy 1.4.x

### DIFF
--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -919,6 +919,10 @@ class AthenaDialect(DefaultDialect):
     @classmethod
     def import_dbapi(cls) -> "ModuleType":
         return pyathena
+    
+    @classmethod
+    def dbapi(cls) -> "ModuleType":
+        return pyathena
 
     def _raw_connection(self, connection: Union[Engine, "Connection"]) -> "PoolProxiedConnection":
         if isinstance(connection, Engine):


### PR DESCRIPTION
Fixes https://github.com/laughingman7743/PyAthena/issues/447